### PR TITLE
Fix dependency to third_robot_laserscan_merger in navigation_gazebo

### DIFF
--- a/cirkit_unit03_navigation_gazebo/launch/autorun.launch
+++ b/cirkit_unit03_navigation_gazebo/launch/autorun.launch
@@ -14,7 +14,7 @@
   </node>
   <!-- laserscan_merger should be executed after all launch files are called --> 
   <node pkg="timed_roslaunch" type="timed_roslaunch.sh"
-    args="1 third_robot_merge_laser third_robot_laserscan_merger.launch"
+    args="1 cirkit_unit03_control laserscan_merger.launch"
     name="timed_roslaunch_merger" output="screen">
   </node>
 </launch>

--- a/cirkit_unit03_navigation_gazebo/launch/autorun_with_human.launch
+++ b/cirkit_unit03_navigation_gazebo/launch/autorun_with_human.launch
@@ -31,7 +31,7 @@
   </node>
   <!-- laserscan_merger should be executed after all launch files are called --> 
   <node pkg="timed_roslaunch" type="timed_roslaunch.sh"
-    args="1 third_robot_merge_laser third_robot_laserscan_merger.launch"
+    args="1 cirkit_unit03_control laserscan_merger.launch"
     name="timed_roslaunch_merger" output="screen">
   </node>
 </launch>


### PR DESCRIPTION
これで`navigation_gazebo`から`third_robot_hogehoge`を抹消できた，つもりです．

laserscan_merger への依存関係は敢えて定義していません．将来的にautorun周りは https://github.com/CIR-KIT-Unit03/cirkit_unit03_whole_issue/issues/10 で挙げられた `cirkit_unit03_apps` ができたら，そこから呼ぶつもりだからです．