### PR TITLE
Fix dependency

### DIFF
--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>controller_interface</exec_depend>
   <exec_depend>controller_manager</exec_depend>
+  <exec_depend>ira_laser_tools</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>lower_step_detector</exec_depend>

--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -15,14 +15,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>controller_interface</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>ira_laser_tools</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>laser_filters</exec_depend>
-  <exec_depend>lower_step_detector</exec_depend>
   <exec_depend>ros_control</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
-  <exec_depend>steer_drive_controller</exec_depend>
-
-  <export>
-  </export>
 </package>

--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>laser_filters</exec_depend>
+  <exec_depend>lower_step_detector</exec_depend>
   <exec_depend>ros_control</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
   <exec_depend>roslaunch</exec_depend>

--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -19,7 +19,6 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>lower_step_detector</exec_depend>
-  <exec_depend>roslaunch</exec_depend>
   <exec_depend>ros_control</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
   <exec_depend>roslaunch</exec_depend>

--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -19,4 +19,5 @@
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>ros_control</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
+  <exec_depend>roslaunch</exec_depend>
 </package>

--- a/cirkit_unit03_control/package.xml
+++ b/cirkit_unit03_control/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>lower_step_detector</exec_depend>
+  <exec_depend>roslaunch</exec_depend>
   <exec_depend>ros_control</exec_depend>
   <exec_depend>ros_controllers</exec_depend>
   <exec_depend>roslaunch</exec_depend>

--- a/cirkit_unit03_description/package.xml
+++ b/cirkit_unit03_description/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>roslaunch</exec_depend>
   <exec_depend>rviz</exec_depend>
   <depend>urdf</depend>
   <exec_depend>xacro</exec_depend>

--- a/cirkit_unit03_description/package.xml
+++ b/cirkit_unit03_description/package.xml
@@ -15,13 +15,10 @@
   <author email="cirkit.infomation@gmail.com">CIR-KIT</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>urdf</depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>roslaunch</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <depend>urdf</depend>
   <exec_depend>xacro</exec_depend>
-
-  <export>
-  </export>
 </package>


### PR DESCRIPTION
https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator/pull/17 の続きをしているのですが，コンフリクトしている問題があります．

- Jenkins のエラーをなくすためには，rosdep のエラーを解除しなければならない．
- rosdep のエラーをなくすためには，aptで登録されていないpkgをdepend からはずさなければならない．
- しかし，depend からpkgを外すと，lanch のtestが通らない．
- すると，travisが通らない．

という状態です．よって以下の方針をとります．

- travisが通る範囲でdependの定義を行う．（これで実行に必要十分な条件が満たされるため）
- その範囲でJenkinsがエラーを吐くなら，諦める．

という感じで直したもののプルリクです．