### PR TITLE
Fix steer drive config

### DIFF
--- a/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller.yaml
+++ b/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller.yaml
@@ -1,0 +1,43 @@
+# cirkit_unit03:
+# Publish all joint states -----------------------------------
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50
+
+# Wheel & Steer
+steer_drive_controller:
+  type                          : "steer_drive_controller/SteerDriveController"
+  rear_wheel                    : 'rear_wheel_joint'
+  front_steer                   : 'front_steer_joint'
+  #publish_rate: 100
+
+  pose_covariance_diagonal      : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
+  twist_covariance_diagonal     : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  wheel_separation_h_multiplier : 2.0 # calibration parameter for odometory
+  #wheel_radius_multiplier      : 1.0
+  #steer_pos_multiplier         : 1.0
+  #cmd_vel_timeout              : 20
+  #base_frame_id                : base_link
+
+  #enable_odom_tf: true
+  #wheel_separation_h           : 0.79 # retriieved from urdf joints
+  #wheel_radius                 : 0.28 # retrieved from urdf joint
+
+  #linear:
+  #  x:
+  #    has_velocity_limits      : true
+  #    max_velocity             : 0.9  # m/s
+  #    min_velocity             : -0.9 # m/s
+  #    has_acceleration_limits  : true
+  #    max_acceleration         : 1.7  # m/s^2
+  #    min_acceleration         : -0.4 # m/s^2
+  #    has_jerk_limits          : true
+  #    max_jerk                 : 5.0 # m/s^3
+  #angular:
+  #  z:
+  #    has_velocity_limits      : true
+  #    max_velocity             : 0.5  # rad/s
+  #    has_acceleration_limits  : true
+  #    max_acceleration         : 1.5  # rad/s^2
+  #    has_jerk_limits          : true
+  #    max_jerk                 : 2.5 # rad/s^3

--- a/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller.yaml
+++ b/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller.yaml
@@ -9,35 +9,35 @@ steer_drive_controller:
   type                          : "steer_drive_controller/SteerDriveController"
   rear_wheel                    : 'rear_wheel_joint'
   front_steer                   : 'front_steer_joint'
-  #publish_rate: 100
+  #publish_rate                  : 100
 
   pose_covariance_diagonal      : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
   twist_covariance_diagonal     : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-  wheel_separation_h_multiplier : 2.0 # calibration parameter for odometory
-  #wheel_radius_multiplier      : 1.0
-  #steer_pos_multiplier         : 1.0
-  #cmd_vel_timeout              : 20
-  #base_frame_id                : base_link
+  wheel_separation_h_multiplier : 2.0 # calibration parameter for angle odometory
+  #wheel_radius_multiplier       : 1.0 # calibration parameter for linear odometory
+  #steer_pos_multiplier          : 1.0
+  #cmd_vel_timeout               : 20
+  #base_frame_id                 : base_link
 
   #enable_odom_tf: true
-  #wheel_separation_h           : 0.79 # retriieved from urdf joints
-  #wheel_radius                 : 0.28 # retrieved from urdf joint
+  #wheel_separation_h            : 0.79 # retriieved from urdf joints
+  #wheel_radius                  : 0.28 # retrieved from urdf joint
 
   #linear:
   #  x:
-  #    has_velocity_limits      : true
-  #    max_velocity             : 0.9  # m/s
-  #    min_velocity             : -0.9 # m/s
-  #    has_acceleration_limits  : true
-  #    max_acceleration         : 1.7  # m/s^2
-  #    min_acceleration         : -0.4 # m/s^2
-  #    has_jerk_limits          : true
-  #    max_jerk                 : 5.0 # m/s^3
+  #    has_velocity_limits       : true
+  #    max_velocity              : 0.9  # m/s
+  #    min_velocity              : -0.9 # m/s
+  #    has_acceleration_limits   : true
+  #    max_acceleration          : 1.7  # m/s^2
+  #    min_acceleration          : -0.4 # m/s^2
+  #    has_jerk_limits           : true
+  #    max_jerk                  : 5.0 # m/s^3
   #angular:
   #  z:
-  #    has_velocity_limits      : true
-  #    max_velocity             : 0.5  # rad/s
-  #    has_acceleration_limits  : true
-  #    max_acceleration         : 1.5  # rad/s^2
-  #    has_jerk_limits          : true
-  #    max_jerk                 : 2.5 # rad/s^3
+  #    has_velocity_limits       : true
+  #    max_velocity              : 0.5  # rad/s
+  #    has_acceleration_limits   : true
+  #    max_acceleration          : 1.5  # rad/s^2
+  #    has_jerk_limits           : true
+  #    max_jerk                  : 2.5 # rad/s^3

--- a/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
+++ b/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
@@ -4,37 +4,40 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 
-# Wheel & Steer (rocker_bogie_controller should be used without namespace)
+# Wheel & Steer
 steer_drive_controller:
-    type        : "steer_drive_controller/SteerDriveController"
-    rear_wheel  : 'rear_wheel_joint'
-    front_steer : 'front_steer_joint'
-    publish_rate: 100
+  type                          : "steer_drive_controller/SteerDriveController"
+  rear_wheel                    : 'rear_wheel_joint'
+  front_steer                   : 'front_steer_joint'
+  #publish_rate: 100
 
-    pose_covariance_diagonal : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
-    twist_covariance_diagonal: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    wheel_separation_multiplier: 1.3
-    wheel_separation_h_multiplier : 2.0
-    wheel_radius_multiplier    : 0.5
-    steer_pos_multiplier       : 0.7
-    cmd_vel_timeout: 20
-    base_frame_id: base_link
+  pose_covariance_diagonal      : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
+  twist_covariance_diagonal     : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  wheel_separation_h_multiplier : 2.0 # calibration parameter for odometory
+  #wheel_radius_multiplier      : 1.0
+  #steer_pos_multiplier         : 1.0
+  #cmd_vel_timeout              : 20
+  #base_frame_id                : base_link
 
-    enable_odom_tf: true
-    wheel_separation_h : 0.79
-    wheel_radius : 0.28
+  #enable_odom_tf: true
+  #wheel_separation_h           : 0.79 # retriieved from urdf joints
+  #wheel_radius                 : 0.28 # retrieved from urdf joint
 
-    linear:
-      x:
-        has_velocity_limits    : true
-        max_velocity           : 0.9  # m/s
-        min_velocity           : -0.9 # m/s
-        has_acceleration_limits: true
-        max_acceleration       : 1.7  # m/s^2
-        min_acceleration       : -0.4 # m/s^2
-    angular:
-      z:
-        has_velocity_limits    : true
-        max_velocity           : 0.5  # rad/s
-        has_acceleration_limits: true
-        max_acceleration       : 1.5  # rad/s^2  #  wheel_right_front_joint_position_controller:
+  #linear:
+  #  x:
+  #    has_velocity_limits      : true
+  #    max_velocity             : 0.9  # m/s
+  #    min_velocity             : -0.9 # m/s
+  #    has_acceleration_limits  : true
+  #    max_acceleration         : 1.7  # m/s^2
+  #    min_acceleration         : -0.4 # m/s^2
+  #    has_jerk_limits          : true
+  #    max_jerk                 : 5.0 # m/s^3
+  #angular:
+  #  z:
+  #    has_velocity_limits      : true
+  #    max_velocity             : 0.5  # rad/s
+  #    has_acceleration_limits  : true
+  #    max_acceleration         : 1.5  # rad/s^2
+  #    has_jerk_limits          : true
+  #    max_jerk                 : 2.5 # rad/s^3

--- a/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
+++ b/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
@@ -9,35 +9,35 @@ steer_drive_controller:
   type                          : "steer_drive_controller/SteerDriveController"
   rear_wheel                    : 'rear_wheel_joint'
   front_steer                   : 'front_steer_joint'
-  #publish_rate: 100
+  #publish_rate                  : 100
 
   pose_covariance_diagonal      : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
   twist_covariance_diagonal     : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-  wheel_separation_h_multiplier : 2.0 # calibration parameter for odometory
-  #wheel_radius_multiplier      : 1.0
-  #steer_pos_multiplier         : 1.0
-  #cmd_vel_timeout              : 20
-  #base_frame_id                : base_link
+  wheel_separation_h_multiplier : 2.0 # calibration parameter for angle odometory
+  #wheel_radius_multiplier       : 1.0 # calibration parameter for linear odometory
+  #steer_pos_multiplier          : 1.0
+  #cmd_vel_timeout               : 20
+  #base_frame_id                 : base_link
 
   #enable_odom_tf: true
-  #wheel_separation_h           : 0.79 # retriieved from urdf joints
-  #wheel_radius                 : 0.28 # retrieved from urdf joint
+  #wheel_separation_h            : 0.79 # retriieved from urdf joints
+  #wheel_radius                  : 0.28 # retrieved from urdf joint
 
   #linear:
   #  x:
-  #    has_velocity_limits      : true
-  #    max_velocity             : 0.9  # m/s
-  #    min_velocity             : -0.9 # m/s
-  #    has_acceleration_limits  : true
-  #    max_acceleration         : 1.7  # m/s^2
-  #    min_acceleration         : -0.4 # m/s^2
-  #    has_jerk_limits          : true
-  #    max_jerk                 : 5.0 # m/s^3
+  #    has_velocity_limits       : true
+  #    max_velocity              : 0.9  # m/s
+  #    min_velocity              : -0.9 # m/s
+  #    has_acceleration_limits   : true
+  #    max_acceleration          : 1.7  # m/s^2
+  #    min_acceleration          : -0.4 # m/s^2
+  #    has_jerk_limits           : true
+  #    max_jerk                  : 5.0 # m/s^3
   #angular:
   #  z:
-  #    has_velocity_limits      : true
-  #    max_velocity             : 0.5  # rad/s
-  #    has_acceleration_limits  : true
-  #    max_acceleration         : 1.5  # rad/s^2
-  #    has_jerk_limits          : true
-  #    max_jerk                 : 2.5 # rad/s^3
+  #    has_velocity_limits       : true
+  #    max_velocity              : 0.5  # rad/s
+  #    has_acceleration_limits   : true
+  #    max_acceleration          : 1.5  # rad/s^2
+  #    has_jerk_limits           : true
+  #    max_jerk                  : 2.5 # rad/s^3

--- a/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
+++ b/cirkit_unit03_control/config/cirkit_unit03_steer_drive_controller_gazebo.yaml
@@ -13,13 +13,13 @@ steer_drive_controller:
 
   pose_covariance_diagonal      : [0.00001, 0.00001, 1000000000000.0, 1000000000000.0, 1000000000000.0, 0.001]
   twist_covariance_diagonal     : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-  wheel_separation_h_multiplier : 2.0 # calibration parameter for angle odometory
+  wheel_separation_h_multiplier : 1.7 # calibration parameter for angle odometory
   #wheel_radius_multiplier       : 1.0 # calibration parameter for linear odometory
-  #steer_pos_multiplier          : 1.0
-  #cmd_vel_timeout               : 20
-  #base_frame_id                 : base_link
+  steer_pos_multiplier          : 1.5
+  cmd_vel_timeout               : 4
+  base_frame_id                 : base_link
 
-  #enable_odom_tf: true
+  enable_odom_tf: true
   #wheel_separation_h            : 0.79 # retriieved from urdf joints
   #wheel_radius                  : 0.28 # retrieved from urdf joint
 

--- a/cirkit_unit03_control/launch/control.launch
+++ b/cirkit_unit03_control/launch/control.launch
@@ -1,6 +1,6 @@
 <launch>
 <!-- Load joint controller configurations from YAML file to parameter server -->
-  <rosparam file="$(find cirkit_unit03_control)/config/cirkit_unit03_steer_drive_controller_gazebo.yaml" command="load" />
+  <rosparam file="$(find cirkit_unit03_control)/config/cirkit_unit03_steer_drive_controller.yaml" command="load" />
 
   <!-- load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="steer_drive_controller joint_state_controller"/>

--- a/cirkit_unit03_description/urdf/cirkit_unit03_macro.xacro
+++ b/cirkit_unit03_description/urdf/cirkit_unit03_macro.xacro
@@ -21,13 +21,19 @@
 
     <!-- wheel macro -->
     <xacro:macro name="rear_wheel">
-        <link name="rear_wheel_link"/>
+        <link name="rear_wheel_link">
+            <collision>
+                <origin rpy="${PI/2} 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <cylinder length="${length_wheel}" radius="${radius_wheel}"/>
+                </geometry>
+            </collision>
+        </link>
         <joint name="rear_wheel_joint" type="continuous">
             <axis xyz="0 1 0"/>
             <parent link="base_link"/>
             <child link="rear_wheel_link"/>
             <origin xyz="${-base_center_x-length_from_base_center_to_wheel_x} 0 ${radius_wheel}"/>
-            <origin xyz="${length_from_base_to_wheel_front_x} 0 ${radius_wheel}"/>
         </joint>
     </xacro:macro>
 


### PR DESCRIPTION
https://github.com/CIR-KIT-Unit03/cirkit_unit03_robot/pull/19 の対策です．

- steer_drive_controller用の設定ファイルを最小構成とした．
- 実機用のyamlを追加作成．
- デフォルト動作のためにxacro を修正．